### PR TITLE
Use Sphinx to generate documentation.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,7 +68,9 @@ instance/
 .scrapy
 
 # Sphinx documentation
-docs/_build/
+docs/api/*
+docs/_rst/*
+docs/_build/*
 
 # PyBuilder
 target/

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -9,10 +9,51 @@
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-#
+
 import os
 import sys
-sys.path.insert(0, os.path.abspath('.'))
+import inspect
+import shutil
+
+__location__ = os.path.join(os.getcwd(), os.path.dirname(
+    inspect.getfile(inspect.currentframe())))
+
+sys.path.insert(0, os.path.join(__location__, '..'))
+
+# -- Run sphinx-apidoc ------------------------------------------------------
+# This hack is necessary since RTD does not issue `sphinx-apidoc` before running
+# `sphinx-build -b html . _build/html`. See Issue:
+# https://github.com/rtfd/readthedocs.org/issues/1139
+# DON'T FORGET: Check the box "Install your project inside a virtualenv using
+# setup.py install" in the RTD Advanced Settings.
+# Additionally it helps us to avoid running apidoc manually
+
+try:  # for Sphinx >= 1.7
+    from sphinx.ext import apidoc
+except ImportError:
+    from sphinx import apidoc
+
+output_dir = os.path.join(__location__, "api")
+module_dir = os.path.join(__location__, "../sc3")
+try:
+    shutil.rmtree(output_dir)
+except FileNotFoundError:
+    pass
+
+try:
+    import sphinx
+    from pkg_resources import parse_version
+
+    cmd_line_template = "sphinx-apidoc -f -o {outputdir} {moduledir}"
+    cmd_line = cmd_line_template.format(outputdir=output_dir, moduledir=module_dir)
+
+    args = cmd_line.split(" ")
+    if parse_version(sphinx.__version__) >= parse_version('1.7'):
+        args = args[1:]
+
+    apidoc.main(args)
+except Exception as e:
+    print("Running `sphinx-apidoc` failed!\n{}".format(e))
 
 
 # -- Project information -----------------------------------------------------
@@ -28,6 +69,11 @@ author = 'Lucas Samaruga'
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
+    'sphinx.ext.autodoc',
+    'sphinx.ext.autosummary',
+    'sphinx.ext.viewcode',
+    'sphinx.ext.doctest',
+    'sphinx.ext.napoleon'
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,52 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
+import os
+import sys
+sys.path.insert(0, os.path.abspath('.'))
+
+
+# -- Project information -----------------------------------------------------
+
+project = 'sc3'
+copyright = '2019, Lucas Samaruga'
+author = 'Lucas Samaruga'
+
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = [
+]
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ['_templates']
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = 'default'
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ['_static']

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,11 +6,6 @@
 sc3
 ===
 
-.. toctree::
-   :maxdepth: 2
-   :caption: Contents:
-
-
 Port of core features from sclang to Python 3, 3.6 for sure maybe >= 3.5 (not
 tested). It is intended to be the same library in a different language and to
 keep sclang elegance in a pythonic way (if possible).
@@ -115,6 +110,18 @@ License
 The sc3 library holds the same license as SuperCollider: sc3 is free software
 available under Version 3 of the GNU General Public License. See COPYING for
 details.
+
+
+Contents
+========
+
+.. toctree::
+   :maxdepth: 2
+
+   License <license>
+   Authors <authors>
+   Changelog <changelog>
+   Module Reference <api/modules>
 
 
 Indices and tables

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,125 @@
+.. sc3 documentation master file, created by
+   sphinx-quickstart on Sun Nov 10 10:26:02 2019.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+sc3
+===
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+
+Port of core features from sclang to Python 3, 3.6 for sure maybe >= 3.5 (not
+tested). It is intended to be the same library in a different language and to
+keep sclang elegance in a pythonic way (if possible).
+
+So far SynthDef compiles and Routine and TempoClock are barely working, for
+that I started form AbstractFunction. Basics are not finished, I’m still
+studding the code. Also I’m not being linear in feature transcription, more
+like jumping and iterating (revisiting and completing) from place to place so
+to have the whole picture, sclang library has features integrated from bottom
+up and between classes. Everything is in a very early stage.
+
+Code is still full of study comments and references (very unprofessional, I
+know) most of them useless, don’t try understand, those are just reminders to
+myself. I will be erasing them gradually. Some original sclang comments were
+kept in code with two slash within python comments (``# //``) and each file has
+a reference to the source (many are obvious but some are not and some names
+were changed for different reasons).
+
+The main reason for this port is Python's capacity of interaction with other
+libraries applicable to composition, sonic-art and alike, and to be able to
+compile synth definitions and send them to the server is very handy.
+
+I still don't know what would be the scope regarding features, what I will get
+finished for sure are server abstractions and interaction.
+
+
+Isn't Python slow?
+------------------
+
+Yes it is and so is sclang, the problem would be realtimeness and that's solved
+the same way for Python [TODO: brief explanation of logical time, interaction
+with the server and time boundaries].
+
+
+Example
+-------
+
+The idea is that you can write the same in Python as in sclang, with the same
+logic regarding multichannel expansion, arguments conversion to Control ugens,
+etc., it should be the same result. For example::
+
+		from sc3.all import *
+
+		# interactive shell run...
+
+		s = Server.local
+		s.boot()
+
+		# wait or error...
+
+		@synthdef.add()
+		def sine(freq=440, amp=0.1, gate=1):
+				sig = SinOsc.ar(freq) * amp
+				sig *= EnvGen.kr(Env.adsr(), gate, done_action=2)
+				Out.ar(0, sig.dup())
+
+		sine.dump_ugens()
+
+		# following lines are meant to be executed one by one as in interactive
+		# session. Commands to the server are asynchronous actions that need a bit
+		# of time for the resource to be available/changed.
+
+		n = Synth('sine')
+		n.set('amp', 0.05)
+		n.set('freq', 220)
+
+		s.query_all_nodes(True)
+
+		n.release()
+		# s.free_all()  # if something went wrong free all nodes.
+
+		s.quit()  # stop server at the end of interactive session or just quit ipython.
+
+
+That's a working example but many things are not finished or tested and some
+are no decided, things may change or move.
+
+
+Install (in develop mode)
+-------------------------
+
+::
+
+		python3 setup.py develop --user
+
+
+Contribute
+----------
+
+- Issue Tracker: https://github.com/smrg-lm/sc3/issues
+- Source Code: https://github.com/smrg-lm/sc3
+
+Support
+-------
+
+If you are having issues, please let us know.
+
+
+License
+-------
+
+The sc3 library holds the same license as SuperCollider: sc3 is free software
+available under Version 3 of the GNU General Public License. See COPYING for
+details.
+
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=.
+set BUILDDIR=_build
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.http://sphinx-doc.org/
+	exit /b 1
+)
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd


### PR DESCRIPTION
Includes an `index.rst` based on `README.md`, and sets autodoc and other Sphinx extensions for autogenerating module documentation from docstrings.

Personally, I also recommend configuring [readthedocs](https://readthedocs.org/) for free hosting and automatic generation on git pushes :)