### PR TITLE
Fix ServerOptions.hw_device_name

### DIFF
--- a/sc3/synth/server.py
+++ b/sc3/synth/server.py
@@ -388,9 +388,9 @@ class ServerOptions():
             flag = Defaults.HW_DEVICE_NAME.flag
             dev = self.hw_device_name
             if isinstance(dev, str):
-                o.extend([flag, str(dev)])
+                o.extend([flag, dev])
             elif isinstance(dev, tuple):
-                o.extend([flag, str(dev[0]), str(dev[1])])
+                o.extend([flag, dev[0], dev[1]])
             else:
                 raise TypeError('hw_device_name must be str or tuple')
         if self.hw_buffer_size != Defaults.HW_BUFFER_SIZE.default:

--- a/sc3/synth/server.py
+++ b/sc3/synth/server.py
@@ -388,9 +388,9 @@ class ServerOptions():
             flag = Defaults.HW_DEVICE_NAME.flag
             dev = self.hw_device_name
             if isinstance(dev, str):
-                o.extend([flag, repr(dev)])
+                o.extend([flag, str(dev)])
             elif isinstance(dev, tuple):
-                o.extend([flag, repr(dev[0]), repr(dev[1])])
+                o.extend([flag, str(dev[0]), str(dev[1])])
             else:
                 raise TypeError('hw_device_name must be str or tuple')
         if self.hw_buffer_size != Defaults.HW_BUFFER_SIZE.default:


### PR DESCRIPTION
At least on Mac, the I/O device name for the server was not settable, because `repr` was adding quote characters to the argument passed to `scsynth`